### PR TITLE
support Chrome via WebExtension browser API Polyfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+web-ext-artifacts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,37 @@ Open an issue, start it with `[RFC]` and explain your reasoning.
 
 The most common way to start is with a concrete use case demonstrating what you want to block or unblock, and which is currently incompatible or not covered by the code of ethics.
 
-## Developer Setup
+## Firefox Developer Setup
 
 1. Clone the repo.
-1. Add the developer extension to your browser.
-   * Firefox: visit [about:debugging](about:debugging) and click `Load Temporary Add-on`.
-   * Chrome: I dunno yet, I haven't tested Chrome yet.
+2. Add the developer extension to Firefox.
+   - visit [about:debugging#/runtime/this-firefox](about:debugging#/runtime/this-firefox) and click `Load Temporary Add-on`.
+3. Or use [web-ext](#use-web-ext)
+
+Follow the Firefox Extension Workshop tutorial:
+<https://extensionworkshop.com/documentation/develop/temporary-installation-in-firefox/>
+
+### Use web-ext
+
+Speed up browser extension development and make development tasks easier with `web-ext`
+
+<https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/>
+
+      npm install --global web-ext
+      web-ext run
+
+This starts Firefox and loads the extension temporarily in the browser
+
+For example, to test the extenstion on Hackernews run this command:
+
+      web-ext run --browser-console --start-url https://news.ycombinator.com
+
+## Chrome Developer Setup
+
+1. Clone the repo.
+2. Install [web-ext](#use-web-ext)
+3. And run the Extension
+
+   ```
+   web-ext run -t chromium --start-url <https://news.ycombinator.com>
+   ```

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,10 @@
     "default_title": "Disengaged"
   },
   "background": {
-    "scripts": ["src/background.js"]
+    "scripts": [
+      "node_modules/webextension-polyfill/dist/browser-polyfill.min.js",
+      "src/background.js"
+    ]
   },
   "permissions": [
     "*://*.youtube.com/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "disengaged",
+  "version": "0.3.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "webextension-polyfill": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.6.0.tgz",
+      "integrity": "sha512-PlYwiX8e4bNZrEeBFxbFFsLtm0SMPxJliLTGdNCA0Bq2XkWrAn2ejUd+89vZm+8BnfFB1BclJyCz3iKsm2atNg==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "disengaged",
+  "version": "0.3.0",
+  "description": "The internet sux rn so I deleted the bad parts",
+  "dependencies": {},
+  "devDependencies": {
+    "webextension-polyfill": "^0.6.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/a13o/disengaged.git"
+  },
+  "author": "a13o",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/a13o/disengaged/issues"
+  },
+  "homepage": "https://github.com/a13o/disengaged#readme"
+}

--- a/src/background.js
+++ b/src/background.js
@@ -132,17 +132,17 @@ async function registerContentScripts () {
         .filter(file => file.match(/.*\.css$/))
         .map(file => `${contentScript.folder}/${file}`)
         .map(file => browser.tabs.insertCSS(null, { file }));
+
+    GLOBAL_SCRIPTS.map(file => browser.tabs.executeScript(null, { file }));
+    contentScript.files
+      .filter(file => file.match(/.*\.js$/))
+      .map(file => `${contentScript.folder}/${file}`)
+      .map(file => browser.tabs.executeScript(null, { file }))
+
     browser.contentScripts.register({
       matches: [contentScript.matches],
       excludeMatches: contentScript.excludeMatches,
       allFrames: !!contentScript.allFrames,
-      js: [].concat(
-        GLOBAL_SCRIPTS
-          .map((file) => { return { file }; }),
-        contentScript.files
-          .filter(file => file.match(/.*\.js$/))
-          .map((file) => { return { file: `${contentScript.folder}/${file}` }; })
-      )
     }).then((rcs) => {
       registeredContentScripts.push(rcs);
     });

--- a/src/background.js
+++ b/src/background.js
@@ -128,13 +128,14 @@ function unregisterContentScripts () {
 
 async function registerContentScripts () {
   CONTENT_SCRIPTS.forEach((contentScript) => {
+    contentScript.files
+        .filter(file => file.match(/.*\.css$/))
+        .map(file => `${contentScript.folder}/${file}`)
+        .map(file => browser.tabs.insertCSS(null, { file }));
     browser.contentScripts.register({
       matches: [contentScript.matches],
       excludeMatches: contentScript.excludeMatches,
       allFrames: !!contentScript.allFrames,
-      css: contentScript.files
-        .filter(file => file.match(/.*\.css$/))
-        .map((file) => { return { file: `${contentScript.folder}/${file}` }; }),
       js: [].concat(
         GLOBAL_SCRIPTS
           .map((file) => { return { file }; }),


### PR DESCRIPTION
I followed the instructions from the Mozilla repo:
https://github.com/mozilla/webextension-polyfill

- [x] Make the CSS injection work
- [x] Make the JS execute
- [ ] Test on Hackernews all the CSS and JS
- [x] ~Test on Twitter all the CSS (broken/outdated at the moment)~
- [ ] Test on YouTube all the CSS and JS
- [ ] Test on Reddit all the CSS and JS
- [ ] Test on YouTube Gaming all the CSS
- [ ] Test on YouTube Music all the CSS and JS
- [ ] Test that the extension does nothing and causes no errors in an unsupported site